### PR TITLE
feat: custom rc path

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ nr -C playground dev
 
 ### Config
 
+```bash
+# ~/.bashrc
+
+# custom configuration file path
+export NI_CONFIG_FILE="$HOME/.config/ni/nirc"
+```
+
 ```ini
 ; ~/.nirc
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,11 +3,15 @@ import path from 'path'
 import ini from 'ini'
 import { Agent } from './agents'
 
+const customRcPath = process.env.NI_CONFIG_FILE
+
 const home = process.platform === 'win32'
   ? process.env.USERPROFILE
   : process.env.HOME
 
-const rcPath = path.join(home || '~/', '.nirc')
+const defaultRcPath = path.join(home || '~/', '.nirc')
+
+const rcPath = customRcPath || defaultRcPath
 
 interface Config {
   defaultAgent: Agent | 'prompt'


### PR DESCRIPTION
Hi, I want to try `ni`, but I want to customize the path to the config file, for example `export NI_CONFIG_FILE="$XDG_CONFIG_HOME/ni/nirc"`