### PR TITLE
feat: support yarn@berry

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -5,7 +5,7 @@ const npmRun = (agent: string) => (args: string[]) => {
 }
 
 export const AGENTS = {
-  npm: {
+  'npm': {
     'run': npmRun('npm'),
     'install': 'npm i',
     'frozen': 'npm ci',
@@ -17,7 +17,7 @@ export const AGENTS = {
     'uninstall': 'npm uninstall {0}',
     'global_uninstall': 'npm uninstall -g {0}',
   },
-  yarn: {
+  'yarn': {
     'run': 'yarn run {0}',
     'install': 'yarn install',
     'frozen': 'yarn install --frozen-lockfile',
@@ -29,7 +29,20 @@ export const AGENTS = {
     'uninstall': 'yarn remove {0}',
     'global_uninstall': 'yarn global remove {0}',
   },
-  pnpm: {
+  'yarn@berry': {
+    'run': 'yarn run {0}',
+    'install': 'yarn install',
+    'frozen': 'yarn install --immutable',
+    // yarn3 removed 'global', see https://github.com/yarnpkg/berry/issues/821
+    'global': 'npm i -g {0}',
+    'add': 'yarn add {0}',
+    'upgrade': 'yarn up {0}',
+    'upgrade-interactive': 'yarn up -i {0}',
+    'execute': 'yarn dlx {0}',
+    'uninstall': 'yarn remove {0}',
+    'global_uninstall': 'npm uninstall -g {0}',
+  },
+  'pnpm': {
     'run': npmRun('pnpm'),
     'install': 'pnpm i',
     'frozen': 'pnpm i --frozen-lockfile',
@@ -55,7 +68,8 @@ export const LOCKS: Record<string, Agent> = {
 }
 
 export const INSTALL_PAGE: Record<Agent, string> = {
-  pnpm: 'https://pnpm.js.org/en/installation',
-  yarn: 'https://yarnpkg.com/getting-started/install',
-  npm: 'https://www.npmjs.com/get-npm',
+  'pnpm': 'https://pnpm.js.org/en/installation',
+  'yarn': 'https://yarnpkg.com/getting-started/install',
+  'yarn@berry': 'https://yarnpkg.com/getting-started/install',
+  'npm': 'https://www.npmjs.com/get-npm',
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,9 +32,9 @@ export async function getConfig(): Promise<Config> {
     let packageManager = ''
     if (result)
       packageManager = JSON.parse(fs.readFileSync(result, 'utf8')).packageManager ?? ''
-    const [, agent] = packageManager.match(new RegExp(`^(${Object.values(LOCKS).join('|')})@.*?$`)) || []
+    const [, agent, version] = packageManager.match(new RegExp(`^(${Object.values(LOCKS).join('|')})@(\d).*?$`)) || []
     if (agent)
-      config = Object.assign({}, defaultConfig, { defaultAgent: agent })
+      config = Object.assign({}, defaultConfig, { defaultAgent: (agent === 'yarn' && version > '1') ? 'yarn@berry' : agent })
     else if (!fs.existsSync(rcPath))
       config = defaultConfig
     else

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,7 @@ export async function getConfig(): Promise<Config> {
       packageManager = JSON.parse(fs.readFileSync(result, 'utf8')).packageManager ?? ''
     const [, agent, version] = packageManager.match(new RegExp(`^(${Object.values(LOCKS).join('|')})@(\d).*?$`)) || []
     if (agent)
-      config = Object.assign({}, defaultConfig, { defaultAgent: (agent === 'yarn' && version > '1') ? 'yarn@berry' : agent })
+      config = Object.assign({}, defaultConfig, { defaultAgent: (agent === 'yarn' && parseInt(version) > 1) ? 'yarn@berry' : agent })
     else if (!fs.existsSync(rcPath))
       config = defaultConfig
     else

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -24,7 +24,7 @@ export async function detect({ autoInstall, cwd }: DetectOptions) {
         const pkg = JSON.parse(fs.readFileSync(packageJSON, 'utf8'))
         if (pkg.packageManager) {
           const [name, version] = pkg.packageManager.split('@')
-          if (name === 'yarn' && version > '1') agent = 'yarn@berry'
+          if (name === 'yarn' && parseInt(version) > 1) agent = 'yarn@berry'
         }
       }
       catch {}

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1,9 +1,10 @@
+import fs from 'fs'
 import path from 'path'
 import execa from 'execa'
 import findUp from 'find-up'
 import terminalLink from 'terminal-link'
 import prompts from 'prompts'
-import { LOCKS, INSTALL_PAGE } from './agents'
+import { LOCKS, INSTALL_PAGE, Agent } from './agents'
 import { cmdExists } from './utils'
 
 export interface DetectOptions {
@@ -13,9 +14,25 @@ export interface DetectOptions {
 
 export async function detect({ autoInstall, cwd }: DetectOptions) {
   const result = await findUp(Object.keys(LOCKS), { cwd })
-  const agent = (result ? LOCKS[path.basename(result)] : null)
 
-  if (agent && !cmdExists(agent)) {
+  let agent: Agent | null = null
+  // handle "packageManager"
+  if (result) {
+    const packageJSON = path.resolve(result, '../package.json')
+    if (fs.existsSync(packageJSON)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(packageJSON, 'utf8'))
+        if (pkg.packageManager) {
+          const [name, version] = pkg.packageManager.split('@')
+          if (name === 'yarn' && version > '1') agent = 'yarn@berry'
+        }
+      }
+      catch {}
+    }
+    agent ||= LOCKS[path.basename(result)]
+  }
+
+  if (agent && !cmdExists(agent.split('@')[0])) {
     if (!autoInstall) {
       console.warn(`Detected ${agent} but it doesn't seem to be installed.\n`)
 

--- a/test/ni/yarn@berry.spec.ts
+++ b/test/ni/yarn@berry.spec.ts
@@ -1,0 +1,22 @@
+import test, { ExecutionContext } from 'ava'
+import { parseNi } from '../../src/commands'
+
+const agent = 'yarn@berry'
+const _ = (arg: string, expected: string) => (t: ExecutionContext) => {
+  t.is(
+    parseNi(agent, arg.split(' ').filter(Boolean)),
+    expected,
+  )
+}
+
+test('empty', _('', 'yarn install'))
+
+test('single add', _('axios', 'yarn add axios'))
+
+test('multiple', _('eslint @types/node', 'yarn add eslint @types/node'))
+
+test('-D', _('eslint @types/node -D', 'yarn add eslint @types/node -D'))
+
+test('global', _('eslint ni -g', 'npm i -g eslint ni'))
+
+test('frozen', _('--frozen', 'yarn install --immutable'))


### PR DESCRIPTION
Previously #50 has added support for `packageManager` field, but it does not detect yarn 2+, which has different command arguments. This pr fixed that.

Yarn 2+ users are likely to stay at the `berry` version branch (as its doc suggested `yarn set version stable`), which means we can just maintain 2 versions of yarn (1 & berry) to support most of the users.

\[Help Wanted\] I myself do not use yarn because of yarn@1's lack of maintaining and yarn@berry's breaking node_modules (the node's convention of resolving modules). Therefore I hope some real yarn 2+ user could help reviewing this pr.

closes #25
