### PR TITLE
docs: Updated PowerShell comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ PowerShell come with a built-in alias `ni` for `New Item`. To remove the alias i
 Create or edit file `C:\Windows\System32\WindowsPowerShell\v1.0\Microsoft.PowerShell_profile.ps1`, adding following line:
 
 ```ps
-Del alias:ni -Force
+Remove-Item Alias:ni -Force -ErrorAction Ignore
 ```
 
 </details>


### PR DESCRIPTION
`Del` itself  is an alias and when working in a restricted PS environment or if the aliases have been altered already, `Del` could not work. Also added `-ErrorAction Ignore` to avoid failing if the `ni` alias doesn't exist.
The PS 7 command or both command sections could also be replaced by this, although the PS 7 command is more modern.