### PR TITLE
fix: when reading the storage.json without content,JSON.parse() repor…

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -12,9 +12,11 @@ const storagePath = resolve(fileURLToPath(import.meta.url), '../_storage.json')
 
 export async function load(fn?: (storage: Storage) => Promise<boolean> | boolean) {
   if (!storage) {
-    storage = existsSync(storagePath)
-      ? JSON.parse(await fs.readFile(storagePath, 'utf-8')) || {}
-      : {}
+    storage = {}
+    if (existsSync(storagePath)) {
+      const data = await fs.readFile(storagePath, 'utf-8')
+      storage = data && JSON.parse(data)
+    }
   }
 
   if (fn) {


### PR DESCRIPTION
…ts an error, and the nr command cannot start normally

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
