### PR TITLE
test: add missing yarn berry test

### DIFF
--- a/test/na/yarn@berry.spec.ts
+++ b/test/na/yarn@berry.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest'
+import { parseNa } from '../../src/commands'
+
+const agent = 'yarn@berry'
+const _ = (arg: string, expected: string) => () => {
+  expect(
+    parseNa(agent, arg.split(' ').filter(Boolean)),
+  ).toBe(
+    expected,
+  )
+}
+
+test('empty', _('', 'yarn'))
+test('foo', _('foo', 'yarn foo'))
+test('run test', _('run test', 'yarn run test'))

--- a/test/nr/yarn@berry.spec.ts
+++ b/test/nr/yarn@berry.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest'
+import { parseNr } from '../../src/commands'
+
+const agent = 'yarn@berry'
+const _ = (arg: string, expected: string) => () => {
+  expect(
+    parseNr(agent, arg.split(' ').filter(Boolean)),
+  ).toBe(
+    expected,
+  )
+}
+
+test('empty', _('', 'yarn run start'))
+
+test('if-present', _('test --if-present', 'yarn run --if-present test'))
+
+test('script', _('dev', 'yarn run dev'))
+
+test('script with arguments', _('build --watch -o', 'yarn run build --watch -o'))
+
+test('colon', _('build:dev', 'yarn run build:dev'))

--- a/test/nu/yarn@berry.spec.ts
+++ b/test/nu/yarn@berry.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest'
+import { parseNu } from '../../src/commands'
+
+const agent = 'yarn@berry'
+const _ = (arg: string, expected: string) => () => {
+  expect(
+    parseNu(agent, arg.split(' ').filter(Boolean)),
+  ).toBe(
+    expected,
+  )
+}
+
+test('empty', _('', 'yarn up'))
+
+test('interactive', _('-i', 'yarn up -i'))


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
x
-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This adds missing three yarn berry tests. Even `na` and `nr` are the same as yarn classic, `nu` is quite different 😄. 
