### PR TITLE
feat: add error message for unsupported commands/package managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ _storage.json
 
 # System files
 .DS_Store
+
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -83,5 +83,3 @@ _storage.json
 
 # System files
 .DS_Store
-
-.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features",
-    "files.insertFinalNewline": true
-  }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
+    "editor.defaultFormatter": "vscode.typescript-language-features",
+    "files.insertFinalNewline": true
   }
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -3,6 +3,12 @@ import { AGENTS } from './agents'
 import { exclude } from './utils'
 import type { Runner } from './runner'
 
+export class UnsupportedCommand extends Error {
+  constructor({ agent, command }: { agent: Agent; command: Command }) {
+    super(`Command "${command}" is not support by agent "${agent}"`)
+  }
+}
+
 export function getCommand(
   agent: Agent,
   command: Command,
@@ -17,7 +23,8 @@ export function getCommand(
     return c(args)
 
   if (!c)
-    throw new Error(`Command "${command}" is not support by agent "${agent}"`)
+    throw new UnsupportedCommand({ agent, command })
+
   return c.replace('{0}', args.join(' ')).trim()
 }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -10,6 +10,7 @@ import { getDefaultAgent, getGlobalAgent } from './config'
 import type { DetectOptions } from './detect'
 import { detect } from './detect'
 import { getVoltaPrefix, remove } from './utils'
+import { UnsupportedCommand } from './parse'
 
 const DEBUG_SIGN = '?'
 
@@ -26,6 +27,9 @@ export async function runCli(fn: Runner, options: DetectOptions = {}) {
     await run(fn, args, options)
   }
   catch (error) {
+    if (error instanceof UnsupportedCommand)
+      console.log(c.red(`\u2717 ${error.message}`))
+
     process.exit(1)
   }
 }


### PR DESCRIPTION
- [x] Add vscode settings for default formatter / final newline (to match eslint)
- [x] Show an error message if the current pkg manager doesn't support a command