### PR TITLE
Feat: add ni --reinstall

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,7 +1,8 @@
+import os from 'node:os'
 import type { Agent, Command } from './agents'
 import { AGENTS } from './agents'
 import { exclude } from './utils'
-import type { Runner } from './runner'
+import type { CommandWithPrompt, Runner } from './runner'
 
 export function getCommand(
   agent: Agent,
@@ -26,21 +27,38 @@ export const parseNi = <Runner>((agent, args, ctx) => {
   if (agent === 'bun')
     args = args.map(i => i === '-D' ? '-d' : i)
 
-  if (args.includes('-g'))
+  let before_actions: (CommandWithPrompt & { tag: 'clean_node_modules' })[] = []
+  if (args.includes('--reinstall') || args.includes('-R')) {
+    args = exclude(args, '--reinstall')
+    args = exclude(args, '-R')
+
+    const node_modules = `${ctx?.cwd || '.'}/node_modules`
+    const command = os.platform() === 'win32' ? `rmdir /s /q ${node_modules}` : `rm -rf ${node_modules}`
+
+    before_actions = [
+      { command, tag: 'clean_node_modules', prompt: `Remove ${node_modules} folder?` },
+    ]
+  }
+
+  if (args.includes('-g')) {
+    if (before_actions.some(action => action.tag === 'clean_node_modules'))
+      console.warn('`--reinstall` / `-R` is not supported with `-g`')
+
     return getCommand(agent, 'global', exclude(args, '-g'))
+  }
 
   if (args.includes('--frozen-if-present')) {
     args = exclude(args, '--frozen-if-present')
-    return getCommand(agent, ctx?.hasLock ? 'frozen' : 'install', args)
+    return [...before_actions, getCommand(agent, ctx?.hasLock ? 'frozen' : 'install', args)]
   }
 
   if (args.includes('--frozen'))
-    return getCommand(agent, 'frozen', exclude(args, '--frozen'))
+    return [...before_actions, getCommand(agent, 'frozen', exclude(args, '--frozen'))]
 
   if (args.length === 0 || args.every(i => i.startsWith('-')))
-    return getCommand(agent, 'install', args)
+    return [...before_actions, getCommand(agent, 'install', args)]
 
-  return getCommand(agent, 'add', args)
+  return [...before_actions, getCommand(agent, 'add', args)]
 })
 
 export const parseNr = <Runner>((agent, args) => {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -44,7 +44,7 @@ export const parseNi = <Runner>((agent, args, ctx) => {
     if (before_actions.some(action => action.tag === 'clean_node_modules'))
       console.warn('`--reinstall` / `-R` is not supported with `-g`')
 
-    return getCommand(agent, 'global', exclude(args, '-g'))
+    return [getCommand(agent, 'global', exclude(args, '-g'))]
   }
 
   if (args.includes('--frozen-if-present')) {

--- a/test/ni/_base.ts
+++ b/test/ni/_base.ts
@@ -1,0 +1,15 @@
+import { expect } from 'vitest'
+import type { RunnerReturn } from '../../src/commands'
+import { parseNi } from '../../src/commands'
+import type { Agent } from '../../src/agents'
+
+export const parseNaTest = (agent: Agent) => {
+  return (arg: string, expected: RunnerReturn) => () => {
+    expect(
+      parseNi(agent, arg.split(' ').filter(Boolean)),
+    ).toEqual(expected)
+  }
+}
+
+const platformRmDir = process.platform === 'win32' ? 'rmdir /s /q' : 'rm -rf'
+export const promptRemoveOfNodeModules = { prompt: 'Remove ./node_modules folder?', command: `${platformRmDir} ./node_modules` }

--- a/test/ni/_base.ts
+++ b/test/ni/_base.ts
@@ -12,4 +12,8 @@ export const parseNaTest = (agent: Agent) => {
 }
 
 const platformRmDir = process.platform === 'win32' ? 'rmdir /s /q' : 'rm -rf'
-export const promptRemoveOfNodeModules = { prompt: 'Remove ./node_modules folder?', command: `${platformRmDir} ./node_modules` }
+export const promptRemoveOfNodeModules = {
+  prompt: 'Remove ./node_modules folder?',
+  command: `${platformRmDir} ./node_modules`,
+  tag: 'clean_node_modules',
+}

--- a/test/ni/bun.spec.ts
+++ b/test/ni/bun.spec.ts
@@ -1,23 +1,18 @@
-import { expect, test } from 'vitest'
-import { parseNi } from '../../src/commands'
+import { test } from 'vitest'
+import { parseNaTest, promptRemoveOfNodeModules } from './_base'
 
-const agent = 'bun'
-const _ = (arg: string, expected: string) => () => {
-  expect(
-    parseNi(agent, arg.split(' ').filter(Boolean)),
-  ).toBe(
-    expected,
-  )
-}
+const _ = parseNaTest('bun')
 
-test('empty', _('', 'bun install'))
+test('empty', _('', ['bun install']))
 
-test('single add', _('axios', 'bun add axios'))
+test('empty reinstall', _('--reinstall', [promptRemoveOfNodeModules, 'bun install']))
 
-test('add dev', _('vite -D', 'bun add vite -d'))
+test('single add', _('axios', ['bun add axios']))
 
-test('multiple', _('eslint @types/node', 'bun add eslint @types/node'))
+test('add dev', _('vite -D', ['bun add vite -d']))
 
-test('global', _('eslint -g', 'bun add -g eslint'))
+test('multiple', _('eslint @types/node', ['bun add eslint @types/node']))
 
-test('frozen', _('--frozen', 'bun install --no-save'))
+test('global', _('eslint -g', ['bun add -g eslint']))
+
+test('frozen', _('--frozen', ['bun install --no-save']))

--- a/test/ni/npm.spec.ts
+++ b/test/ni/npm.spec.ts
@@ -1,23 +1,18 @@
-import { expect, test } from 'vitest'
-import { parseNi } from '../../src/commands'
+import { test } from 'vitest'
+import { parseNaTest, promptRemoveOfNodeModules } from './_base'
 
-const agent = 'npm'
-const _ = (arg: string, expected: string) => () => {
-  expect(
-    parseNi(agent, arg.split(' ').filter(Boolean)),
-  ).toBe(
-    expected,
-  )
-}
+const _ = parseNaTest('npm')
 
-test('empty', _('', 'npm i'))
+test('empty', _('', ['npm i']))
 
-test('single add', _('axios', 'npm i axios'))
+test('empty reinstall', _('--reinstall', [promptRemoveOfNodeModules, 'npm i']))
 
-test('multiple', _('eslint @types/node', 'npm i eslint @types/node'))
+test('single add', _('axios', ['npm i axios']))
 
-test('-D', _('eslint @types/node -D', 'npm i eslint @types/node -D'))
+test('multiple', _('eslint @types/node', ['npm i eslint @types/node']))
 
-test('global', _('eslint -g', 'npm i -g eslint'))
+test('-D', _('eslint @types/node -D', ['npm i eslint @types/node -D']))
 
-test('frozen', _('--frozen', 'npm ci'))
+test('global', _('eslint -g', ['npm i -g eslint']))
+
+test('frozen', _('--frozen', ['npm ci']))

--- a/test/ni/pnpm.spec.ts
+++ b/test/ni/pnpm.spec.ts
@@ -1,26 +1,21 @@
-import { expect, test } from 'vitest'
-import { parseNi } from '../../src/commands'
+import { test } from 'vitest'
+import { parseNaTest, promptRemoveOfNodeModules } from './_base'
 
-const agent = 'pnpm'
-const _ = (arg: string, expected: string) => () => {
-  expect(
-    parseNi(agent, arg.split(' ').filter(Boolean)),
-  ).toBe(
-    expected,
-  )
-}
+const _ = parseNaTest('pnpm')
 
-test('empty', _('', 'pnpm i'))
+test('empty', _('', ['pnpm i']))
 
-test('single add', _('axios', 'pnpm add axios'))
+test('empty reinstall', _('--reinstall', [promptRemoveOfNodeModules, 'pnpm i']))
 
-test('multiple', _('eslint @types/node', 'pnpm add eslint @types/node'))
+test('single add', _('axios', ['pnpm add axios']))
 
-test('-D', _('-D eslint @types/node', 'pnpm add -D eslint @types/node'))
+test('multiple', _('eslint @types/node', ['pnpm add eslint @types/node']))
 
-test('global', _('eslint -g', 'pnpm add -g eslint'))
+test('-D', _('-D eslint @types/node', ['pnpm add -D eslint @types/node']))
 
-test('frozen', _('--frozen', 'pnpm i --frozen-lockfile'))
+test('global', _('eslint -g', ['pnpm add -g eslint']))
 
-test('forward1', _('--anything', 'pnpm i --anything'))
-test('forward2', _('-a', 'pnpm i -a'))
+test('frozen', _('--frozen', ['pnpm i --frozen-lockfile']))
+
+test('forward1', _('--anything', ['pnpm i --anything']))
+test('forward2', _('-a', ['pnpm i -a']))

--- a/test/ni/yarn.spec.ts
+++ b/test/ni/yarn.spec.ts
@@ -1,23 +1,18 @@
-import { expect, test } from 'vitest'
-import { parseNi } from '../../src/commands'
+import { test } from 'vitest'
+import { parseNaTest, promptRemoveOfNodeModules } from './_base'
 
-const agent = 'yarn'
-const _ = (arg: string, expected: string) => () => {
-  expect(
-    parseNi(agent, arg.split(' ').filter(Boolean)),
-  ).toBe(
-    expected,
-  )
-}
+const _ = parseNaTest('yarn')
 
-test('empty', _('', 'yarn install'))
+test('empty', _('', ['yarn install']))
 
-test('single add', _('axios', 'yarn add axios'))
+test('empty reinstall', _('--reinstall', [promptRemoveOfNodeModules, 'yarn install']))
 
-test('multiple', _('eslint @types/node', 'yarn add eslint @types/node'))
+test('single add', _('axios', ['yarn add axios']))
 
-test('-D', _('eslint @types/node -D', 'yarn add eslint @types/node -D'))
+test('multiple', _('eslint @types/node', ['yarn add eslint @types/node']))
 
-test('global', _('eslint ni -g', 'yarn global add eslint ni'))
+test('-D', _('eslint @types/node -D', ['yarn add eslint @types/node -D']))
 
-test('frozen', _('--frozen', 'yarn install --frozen-lockfile'))
+test('global', _('eslint ni -g', ['yarn global add eslint ni']))
+
+test('frozen', _('--frozen', ['yarn install --frozen-lockfile']))

--- a/test/ni/yarn@berry.spec.ts
+++ b/test/ni/yarn@berry.spec.ts
@@ -1,23 +1,18 @@
-import { expect, test } from 'vitest'
-import { parseNi } from '../../src/commands'
+import { test } from 'vitest'
+import { parseNaTest, promptRemoveOfNodeModules } from './_base'
 
-const agent = 'yarn@berry'
-const _ = (arg: string, expected: string) => () => {
-  expect(
-    parseNi(agent, arg.split(' ').filter(Boolean)),
-  ).toBe(
-    expected,
-  )
-}
+const _ = parseNaTest('yarn@berry')
 
-test('empty', _('', 'yarn install'))
+test('empty', _('', ['yarn install']))
 
-test('single add', _('axios', 'yarn add axios'))
+test('empty reinstall', _('--reinstall', [promptRemoveOfNodeModules, 'yarn install']))
 
-test('multiple', _('eslint @types/node', 'yarn add eslint @types/node'))
+test('single add', _('axios', ['yarn add axios']))
 
-test('-D', _('eslint @types/node -D', 'yarn add eslint @types/node -D'))
+test('multiple', _('eslint @types/node', ['yarn add eslint @types/node']))
 
-test('global', _('eslint ni -g', 'npm i -g eslint ni'))
+test('-D', _('eslint @types/node -D', ['yarn add eslint @types/node -D']))
 
-test('frozen', _('--frozen', 'yarn install --immutable'))
+test('global', _('eslint ni -g', ['npm i -g eslint ni']))
+
+test('frozen', _('--frozen', ['yarn install --immutable']))


### PR DESCRIPTION
`ni --reinstall` / `ni -R` deletes node_modules before running install

Notes: the `tag` property on `CommandWithPrompt` was added for easier checking of specific flows i.e. delete_node_modules isn't allowed when doing `ni -g`, same for a nother PR I want to open `ni --full or --clean` which will delete the lock file and rerun `ni` (which also isn't supported for -g, but also not in i.e. ci)