### PR TITLE
feat: rename nx to nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ nr -
 
 <br>
 
-### `nx` - execute
+### `nix` - execute (previously `nx`)
 
 ```bash
-nx vitest
+nix vitest
 
 # npx vitest
 # yarn dlx vitest
@@ -253,4 +253,12 @@ $profileContent = Get-Content $profile
 if ($profileContent -notcontains $profileEntry) {
   $profileEntry | Out-File $profile -Append -Force
 }
+```
+
+#### `nx` is no longer available
+
+We renamed `nx` to `nix` to avoid conflicts with the other existing tool - [nx](https://nx.dev/). If you don't use [nx](https://nx.dev/) and still want the old `nx` behavior you can create an alias on your shell configuration file (`.zshrc`, `.bashrc`, etc).
+
+```bash
+alias nx="nix"
 ```

--- a/bin/nix.mjs
+++ b/bin/nix.mjs
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 'use strict'
-import '../dist/nx.mjs'
+import '../dist/nix.mjs'

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "nci": "bin/nci.mjs",
     "nr": "bin/nr.mjs",
     "nu": "bin/nu.mjs",
-    "nx": "bin/nx.mjs",
+    "nix": "bin/nix.mjs",
     "na": "bin/na.mjs",
     "nun": "bin/nun.mjs"
   },

--- a/src/commands/nix.ts
+++ b/src/commands/nix.ts
@@ -1,0 +1,4 @@
+import { parseNix } from '../parse'
+import { runCli } from '../runner'
+
+runCli(parseNix)

--- a/src/commands/nx.ts
+++ b/src/commands/nx.ts
@@ -1,4 +1,0 @@
-import { parseNx } from '../parse'
-import { runCli } from '../runner'
-
-runCli(parseNx)

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -68,7 +68,7 @@ export const parseNun = <Runner>((agent, args) => {
   return getCommand(agent, 'uninstall', args)
 })
 
-export const parseNx = <Runner>((agent, args) => {
+export const parseNix = <Runner>((agent, args) => {
   return getCommand(agent, 'execute', args)
 })
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -48,7 +48,7 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
     console.log(c.green(c.bold('@antfu/ni')) + c.dim(` use the right package manager v${version}\n`))
     console.log(`ni   ${dash}  install`)
     console.log(`nr   ${dash}  run`)
-    console.log(`nx   ${dash}  execute`)
+    console.log(`nix  ${dash}  execute`)
     console.log(`nu   ${dash}  upgrade`)
     console.log(`nun  ${dash}  uninstall`)
     console.log(`nci  ${dash}  clean install`)

--- a/test/nx/bun.spec.ts
+++ b/test/nx/bun.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from 'vitest'
-import { parseNx } from '../../src/commands'
+import { parseNix } from '../../src/commands'
 
 const agent = 'bun'
 const _ = (arg: string, expected: string) => () => {
   expect(
-    parseNx(agent, arg.split(' ').filter(Boolean)),
+    parseNix(agent, arg.split(' ').filter(Boolean)),
   ).toBe(
     expected,
   )

--- a/test/nx/npm.spec.ts
+++ b/test/nx/npm.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from 'vitest'
-import { parseNx } from '../../src/commands'
+import { parseNix } from '../../src/commands'
 
 const agent = 'npm'
 const _ = (arg: string, expected: string) => () => {
   expect(
-    parseNx(agent, arg.split(' ').filter(Boolean)),
+    parseNix(agent, arg.split(' ').filter(Boolean)),
   ).toBe(
     expected,
   )

--- a/test/nx/pnpm.spec.ts
+++ b/test/nx/pnpm.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from 'vitest'
-import { parseNx } from '../../src/commands'
+import { parseNix } from '../../src/commands'
 
 const agent = 'pnpm'
 const _ = (arg: string, expected: string) => () => {
   expect(
-    parseNx(agent, arg.split(' ').filter(Boolean)),
+    parseNix(agent, arg.split(' ').filter(Boolean)),
   ).toBe(
     expected,
   )

--- a/test/nx/yarn.spec.ts
+++ b/test/nx/yarn.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from 'vitest'
-import { parseNx } from '../../src/commands'
+import { parseNix } from '../../src/commands'
 
 const agent = 'yarn'
 const _ = (arg: string, expected: string) => () => {
   expect(
-    parseNx(agent, arg.split(' ').filter(Boolean)),
+    parseNix(agent, arg.split(' ').filter(Boolean)),
   ).toBe(
     expected,
   )

--- a/test/nx/yarn@berry.spec.ts
+++ b/test/nx/yarn@berry.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from 'vitest'
-import { parseNx } from '../../src/commands'
+import { parseNix } from '../../src/commands'
 
 const agent = 'yarn@berry'
 const _ = (arg: string, expected: string) => () => {
   expect(
-    parseNx(agent, arg.split(' ').filter(Boolean)),
+    parseNix(agent, arg.split(' ').filter(Boolean)),
   ).toBe(
     expected,
   )


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Due to a conflict with the existing tool [nx](https://nx.dev/), a pretty popular tool, we find it better to rename `nx` to `nix` for compatibility.

Everyone can still create an alias if they still want to use `nix` as `nx`.

### Linked Issues
#118 
