### PR TITLE
fix: windows cmd detection

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ export function cmdExists(cmd: string) {
     // #8
     execSync(
       os.platform() === 'win32'
-        ? `cmd /c "(help ${cmd} > nul || exit 0) && where ${cmd} > nul 2> nul"`
+        ? `where ${cmd} > nul 2> nul"`
         : `command -v ${cmd}`,
     )
     return true


### PR DESCRIPTION
On [my windows install](https://github.com/Atlas-OS/Atlas), the `help` command doesn't exist.
This will throw an error every time I run `ni` or `nr`

```
'help' is not recognized as an internal or external command,
operable program or batch file.
```

The detection with `where` should be sufficient anyway.

![image](https://user-images.githubusercontent.com/17879327/218431890-51c67419-70c2-4e1f-a2b1-d192e90a7167.png)
