### PR TITLE
Add support for pnpm exec command

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -19,7 +19,7 @@ const yarn = {
 }
 const pnpm = {
   'agent': 'pnpm {0}',
-  'run': 'pnpm run {0}',
+  'run': 'pnpm {0}',
   'install': 'pnpm i {0}',
   'frozen': 'pnpm i --frozen-lockfile',
   'global': 'pnpm add -g {0}',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Contrary to `yarn run`, [`pnpm run`](https://pnpm.io/cli/run) only runs scripts defined in the project's `package.json` file and doesn't work for shell commands of installed dependencies located in `node_modules/.bin`. To run those commands, one has to use the [`pnpm exec` command](https://pnpm.io/cli/exec), instead.

Since the command `nr` translates to `pnpm run`, it means it can't be used to run a project's shell command in a pnpm projects.

The following won't work in a pnpm project:

```
nr jest
```

This can be fixed by using the short form of the command, and so translating `nr` to `pnpm`. When using the short form, pnpm will try to run first a defined script if present, or otherwise, run a shell command. This is similar to the behavior of `yarn run`.