### PR TITLE
docs: update powershell instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ if (-not (Test-Path $profile)) {
 $profileEntry = 'Remove-Item Alias:ni -Force -ErrorAction Ignore'
 $profileContent = Get-Content $profile
 if ($profileContent -notcontains $profileEntry) {
-  $profileEntry | Out-File $profile -Append -Force
+  ("`n" + $profileEntry) | Out-File $profile -Append -Force -Encoding UTF8
 }
 ```
 


### PR DESCRIPTION
fix: 1. The newly added $profileEntry content did not start on a new line, causing it to be appended twice to the ps1 file. 2. Not specifying the file encoding resulted in garbled content when appending.

### Description

1. The newly added $profileEntry content did not start on a new line, causing it to be appended twice to the ps1 file.
2. Not specifying the file encoding resulted in garbled content when appending.

### Linked Issues

### Additional context

