### PR TITLE
feat: add flag to show agent versions

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -82,7 +82,7 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
     args.splice(0, 2)
   }
 
-  if (args.length === 1 && (args[0] === '-V')) {
+  if (args.length === 1 && (args[0]?.toLowerCase() === '-v')) {
     const getV = (a: string, o?: ExecaOptions) => execaCommand(`${a} -v`, o).then(e => e.stdout).then(e => e.startsWith('v') ? e : `v${e}`)
     const globalAgentPromise = getGlobalAgent()
     const globalAgentVersionPromise = globalAgentPromise.then(getV)
@@ -90,14 +90,15 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
     const agentVersionPromise = agentPromise.then(a => a && getV(a, { cwd }))
     const nodeVersionPromise = getV('node', { cwd })
 
-    console.log(`@antfu/ni v${version}`)
-    console.log(`node      ${await nodeVersionPromise}`)
+    console.log(`@antfu/ni  ${c.cyan(`v${version}`)}`)
+    console.log(`node       ${c.green(await nodeVersionPromise)}`)
     const [agent, agentVersion] = await Promise.all([agentPromise, agentVersionPromise])
     if (agent)
-      console.log(`${agent.padEnd(9)} ${agentVersion}`)
-    else console.log('agent     no lock file')
+      console.log(`${agent.padEnd(10)} ${c.blue(agentVersion)}`)
+    else
+      console.log('agent      no lock file')
     const [globalAgent, globalAgentVersion] = await Promise.all([globalAgentPromise, globalAgentVersionPromise])
-    console.log(`${(`${globalAgent} -g`).padEnd(9)} ${globalAgentVersion}`)
+    console.log(`${(`${globalAgent} -g`).padEnd(10)} ${c.blue(globalAgentVersion)}`)
     return
   }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR adds `ni -V` flag which shows agent and node versions additionally to ni version
```
PS D:\repos\ni> ni -V
@antfu/ni v0.21.6
node      v20.5.1
pnpm      v8.6.12
npm -g    v9.8.0
```
#### Why
I wanted so see the agent and node versions, same as `tsx` does with node version
```
PS D:\repos\ni> tsx -v
tsx v3.12.7
node v20.5.1
```

### Linked Issues

none

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
- not sure about flag name
- maybe a long flag name alternative is required
- this was not added to just `--version` because it has another format *and takes a few second to run*, 
- maybe add versions of something else? (likely out-of-scope)
- I've made text appear in columns because I like it, but you may close to remove it
- edit: config file location also can be useful as well