### PR TITLE
feat: implement `nrx` command

### DIFF
--- a/bin/nrx.mjs
+++ b/bin/nrx.mjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+'use strict'
+import '../dist/nrx.mjs'

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "nr": "bin/nr.mjs",
     "nu": "bin/nu.mjs",
     "nlx": "bin/nlx.mjs",
+    "nrx": "bin/nrx.mjs",
     "na": "bin/na.mjs",
     "nun": "bin/nun.mjs"
   },

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,9 +1,28 @@
-function npmRun(agent: string) {
+function npmRun(agent: string, run = 'run') {
   return (args: string[]) => {
     if (args.length > 1)
-      return `${agent} run ${args[0]} -- ${args.slice(1).join(' ')}`
-    else return `${agent} run ${args[0]}`
+      return `${agent} ${run} ${args[0]} -- ${args.slice(1).join(' ')}`
+    else return `${agent} ${run} ${args[0]}`
   }
+}
+
+const npm = {
+  'agent': 'npm {0}',
+  'run': npmRun('npm'),
+  'install': 'npm i {0}',
+  'frozen': 'npm ci',
+  'global': 'npm i -g {0}',
+  'add': 'npm i {0}',
+  'upgrade': 'npm update {0}',
+  'upgrade-interactive': null,
+  'execute': 'npx {0}',
+  /**
+   * just `npm exec` can install packages
+   * requires `--` as `npm exec ni -v` shows npm version
+   */
+  'bin': npmRun('npm', 'exec --no'),
+  'uninstall': 'npm uninstall {0}',
+  'global_uninstall': 'npm uninstall -g {0}',
 }
 
 const yarn = {
@@ -15,10 +34,23 @@ const yarn = {
   'add': 'yarn add {0}',
   'upgrade': 'yarn upgrade {0}',
   'upgrade-interactive': 'yarn upgrade-interactive {0}',
-  'execute': 'npx {0}',
+  'execute': 'npx --no-install {0}',
+  'bin': 'yarn run {0}',
   'uninstall': 'yarn remove {0}',
   'global_uninstall': 'yarn global remove {0}',
 }
+const yarnBerry = {
+  ...yarn,
+  'frozen': 'yarn install --immutable',
+  'upgrade': 'yarn up {0}',
+  'upgrade-interactive': 'yarn up -i {0}',
+  'execute': 'yarn dlx {0}',
+  'bin': 'yarn exec {0}',
+  /** Yarn 2+ removed 'global', see https://github.com/yarnpkg/berry/issues/821 */
+  'global': 'npm i -g {0}',
+  'global_uninstall': 'npm uninstall -g {0}',
+}
+
 const pnpm = {
   'agent': 'pnpm {0}',
   'run': 'pnpm run {0}',
@@ -29,9 +61,16 @@ const pnpm = {
   'upgrade': 'pnpm update {0}',
   'upgrade-interactive': 'pnpm update -i {0}',
   'execute': 'pnpm dlx {0}',
+  'bin': 'pnpm exec {0}',
   'uninstall': 'pnpm remove {0}',
   'global_uninstall': 'pnpm remove --global {0}',
 }
+/** pnpm v6.x or below */
+const pnpm6 = {
+  ...pnpm,
+  run: npmRun('pnpm'),
+}
+
 const bun = {
   'agent': 'bun {0}',
   'run': 'bun run {0}',
@@ -42,46 +81,24 @@ const bun = {
   'upgrade': 'bun update {0}',
   'upgrade-interactive': 'bun update {0}',
   'execute': 'bunx {0}',
+  // needs a test
+  // may install packages, maybe something other needed (or flags)
+  'bin': 'bunx {0}',
   'uninstall': 'bun remove {0}',
   'global_uninstall': 'bun remove -g {0}',
 }
 
 export const AGENTS = {
-  'npm': {
-    'agent': 'npm {0}',
-    'run': npmRun('npm'),
-    'install': 'npm i {0}',
-    'frozen': 'npm ci',
-    'global': 'npm i -g {0}',
-    'add': 'npm i {0}',
-    'upgrade': 'npm update {0}',
-    'upgrade-interactive': null,
-    'execute': 'npx {0}',
-    'uninstall': 'npm uninstall {0}',
-    'global_uninstall': 'npm uninstall -g {0}',
-  },
+  'npm': npm,
   'yarn': yarn,
-  'yarn@berry': {
-    ...yarn,
-    'frozen': 'yarn install --immutable',
-    'upgrade': 'yarn up {0}',
-    'upgrade-interactive': 'yarn up -i {0}',
-    'execute': 'yarn dlx {0}',
-    // Yarn 2+ removed 'global', see https://github.com/yarnpkg/berry/issues/821
-    'global': 'npm i -g {0}',
-    'global_uninstall': 'npm uninstall -g {0}',
-  },
+  'yarn@berry': yarnBerry,
   'pnpm': pnpm,
-  // pnpm v6.x or below
-  'pnpm@6': {
-    ...pnpm,
-    run: npmRun('pnpm'),
-  },
+  'pnpm@6': pnpm6,
   'bun': bun,
-}
+} satisfies Record<string, Record<Command, string | null | ((a: string[]) => string)>>
 
 export type Agent = keyof typeof AGENTS
-export type Command = keyof typeof AGENTS.npm
+export type Command = keyof typeof npm
 
 export const agents = Object.keys(AGENTS) as Agent[]
 

--- a/src/commands/nrx.ts
+++ b/src/commands/nrx.ts
@@ -1,0 +1,4 @@
+import { parseNrx } from '../parse'
+import { runCli } from '../runner'
+
+runCli(parseNrx)

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -18,18 +18,26 @@ export function getCommand(
     throw new Error(`Unsupported agent "${agent}"`)
 
   const c = AGENTS[agent][command]
-
-  if (typeof c === 'function')
-    return c(args)
-
   if (!c)
     throw new UnsupportedCommand({ agent, command })
 
-  const quote = (arg: string) => (!arg.startsWith('--') && arg.includes(' '))
-    ? JSON.stringify(arg)
-    : arg
+  let cmd = ''
 
-  return c.replace('{0}', args.map(quote).join(' ')).trim()
+  if (typeof c === 'function') {
+    cmd = c(args)
+  }
+  else {
+    const quote = (arg: string) => (!arg.startsWith('--') && arg.includes(' '))
+      ? JSON.stringify(arg)
+      : arg
+    cmd = c.replace('{0}', args.map(quote).join(' ')).trim()
+  }
+
+  // DEBUG: remove for build
+  // eslint-disable-next-line no-console
+  console.log('>', cmd)
+
+  return cmd
 }
 
 export const parseNi = <Runner>((agent, args, ctx) => {
@@ -81,6 +89,10 @@ export const parseNun = <Runner>((agent, args) => {
 
 export const parseNlx = <Runner>((agent, args) => {
   return getCommand(agent, 'execute', args)
+})
+
+export const parseNrx = <Runner>((agent, args) => {
+  return getCommand(agent, 'bin', args)
 })
 
 export const parseNa = <Runner>((agent, args) => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR adds `nrx` command, which is an "execute local binary" command:
```
> nrx cowsayjs moo
> npm exec --no cowsayjs moo
> yarn@1 run cowsayjs moo
> yarn exec cowsayjs moo
> pnpm exec cowsayjs moo
```

Unlike `dlx`-style commands (`npx`/`yarn dlx`) this can't install new packages and must use existing ones
If the binary is missing, this command is guaranteed to fail

### Linked Issues
(unrelated) #140

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This Draft PR is missing:
- [ ] check if there's `nrx` command for some other stuff (as there were `nx` and `nix`)
- [ ] add tests
- [ ] add readme docs
- [ ] add a proper bun command
- [ ] remove `console.log('>', command)`
- [ ] manually test in pnpm@6
- [x] manually test that `nrx` can run binary
- [x] manually test that `nrx` cannot run missing binary

Please tell me if there is interest in this command, so I can either procees to making tests/docs or leave it as-is
(it works for me locally, so I don't really need tests/docs if this is not going to be upstreamed)