### PR TITLE
Fix `-v` flag not working for `yarn@berry`

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -84,7 +84,7 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
     args.splice(0, 2)
   }
 
-  if (args.length === 1 && (args[0]?.toLowerCase() === '-v')) {
+  if (args.length === 1 && (args[0]?.toLowerCase() === '-v' || args[0] === '--version')) {
     const getCmd = (a: Agent) => agents.includes(a) ? getCommand(a, 'agent', ['-v']) : `${a} -v`
     const getV = (a: string, o?: ExecaOptions) => execaCommand(getCmd(a as Agent), o).then(e => e.stdout).then(e => e.startsWith('v') ? e : `v${e}`)
     const globalAgentPromise = getGlobalAgent()

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -113,13 +113,14 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
   if (args.length === 1 && ['-h', '--help'].includes(args[0])) {
     const dash = c.dim('-')
     console.log(c.green(c.bold('@antfu/ni')) + c.dim(` use the right package manager v${version}\n`))
-    console.log(`ni   ${dash}  install`)
-    console.log(`nr   ${dash}  run`)
-    console.log(`nlx  ${dash}  execute`)
-    console.log(`nu   ${dash}  upgrade`)
-    console.log(`nun  ${dash}  uninstall`)
-    console.log(`nci  ${dash}  clean install`)
-    console.log(`na   ${dash}  agent alias`)
+    console.log(`ni    ${dash}  install`)
+    console.log(`nr    ${dash}  run`)
+    console.log(`nlx   ${dash}  execute`)
+    console.log(`nu    ${dash}  upgrade`)
+    console.log(`nun   ${dash}  uninstall`)
+    console.log(`nci   ${dash}  clean install`)
+    console.log(`na    ${dash}  agent alias`)
+    console.log(`ni -v ${dash}  show used agent`)
     console.log(c.yellow('\ncheck https://github.com/antfu/ni for more documentation.'))
     return
   }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -12,7 +12,7 @@ import { getDefaultAgent, getGlobalAgent } from './config'
 import type { DetectOptions } from './detect'
 import { detect } from './detect'
 import { getVoltaPrefix, remove } from './utils'
-import { UnsupportedCommand } from './parse'
+import { UnsupportedCommand, getCommand } from './parse'
 
 const DEBUG_SIGN = '?'
 
@@ -85,7 +85,8 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
   }
 
   if (args.length === 1 && (args[0]?.toLowerCase() === '-v')) {
-    const getV = (a: string, o?: ExecaOptions) => execaCommand(`${a} -v`, o).then(e => e.stdout).then(e => e.startsWith('v') ? e : `v${e}`)
+    const getCmd = (a: Agent) => agents.includes(a) ? getCommand(a, 'agent', ['-v']) : `${a} -v`
+    const getV = (a: string, o?: ExecaOptions) => execaCommand(getCmd(a as Agent), o).then(e => e.stdout).then(e => e.startsWith('v') ? e : `v${e}`)
     const globalAgentPromise = getGlobalAgent()
     const globalAgentVersionPromise = globalAgentPromise.then(getV)
     const agentPromise = detect({ ...options, cwd }).then(a => a || '')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
This PR fixes `ni -v`not showing `yarn@berry` version due to passing `yarn@berry` as executable name.  
With this commit `getCommand` is used to determine proper agent executable (`node` is handled separately.)
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
#169

### Additional context
This PR also adds `--version` flag alias and a tip in separate commits, those commits may be safely dropped/reverted if they are not needed.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
