### PR TITLE
feat: support detect the range version of packageManager

### DIFF
--- a/src/detect.ts
+++ b/src/detect.ts
@@ -32,7 +32,7 @@ export async function detect({ autoInstall, programmatic, cwd }: DetectOptions =
     try {
       const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
       if (typeof pkg.packageManager === 'string') {
-        const [name, ver] = pkg.packageManager.split('@')
+        const [name, ver] = pkg.packageManager.replace(/^\^/, '').split('@')
         version = ver
         if (name === 'yarn' && Number.parseInt(ver) > 1)
           agent = 'yarn@berry'

--- a/test/fixtures/packager/pnpm-version-range/package.json
+++ b/test/fixtures/packager/pnpm-version-range/package.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "^pnpm@8.0.0"
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->


### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Issue from https://github.com/ant-design/ant-design/pull/45327?notification_referrer_id=NT_kwDOAcKkeLM4MDQzMTU0MTMwOjI5NTMzMzA0#issuecomment-1767488121

Corepack has supported a range version for a long time. You can see https://github.com/nodejs/corepack/pull/136

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
