### PR TITLE
fix: packager detect tests are not running

### DIFF
--- a/test/programmatic/__snapshots__/detect.spec.ts.snap
+++ b/test/programmatic/__snapshots__/detect.spec.ts.snap
@@ -20,10 +20,10 @@ exports[`packager > npm 1`] = `"npm"`;
 
 exports[`packager > pnpm 1`] = `"pnpm"`;
 
-exports[`packager > pnpm@6 1`] = `"pnpm"`;
+exports[`packager > pnpm@6 1`] = `"pnpm@6"`;
 
 exports[`packager > unknown 1`] = `null`;
 
 exports[`packager > yarn 1`] = `"yarn"`;
 
-exports[`packager > yarn@berry 1`] = `"yarn"`;
+exports[`packager > yarn@berry 1`] = `"yarn@berry"`;

--- a/test/programmatic/detect.spec.ts
+++ b/test/programmatic/detect.spec.ts
@@ -7,11 +7,11 @@ import { AGENTS, detect } from '../../src'
 
 let basicLog: SpyInstance, errorLog: SpyInstance, warnLog: SpyInstance, infoLog: SpyInstance
 
-function detectTest(agent: string) {
+function detectTest(fixture: string, agent: string) {
   return async () => {
     const cwd = await fs.mkdtemp(path.join(tmpdir(), 'ni-'))
-    const fixture = path.join(__dirname, '..', 'fixtures', 'lockfile', agent)
-    await fs.copy(fixture, cwd)
+    const dir = path.join(__dirname, '..', 'fixtures', fixture, agent)
+    await fs.copy(dir, cwd)
 
     expect(await detect({ programmatic: true, cwd })).toMatchSnapshot()
   }
@@ -33,7 +33,7 @@ const fixtures = ['lockfile', 'packager']
 
 // matrix testing of: fixtures x agents
 fixtures.forEach(fixture => describe(fixture, () => agents.forEach((agent) => {
-  it(agent, detectTest(agent))
+  it(agent, detectTest(fixture, agent))
 
   it('no logs', () => {
     expect(basicLog).not.toHaveBeenCalled()


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
`test/programmatic/detect.spec.ts` is supposed to run _matrix testing of: fixtures x agents_, however `fixture` is not passed down. As a result, the test runs on `lockfile` twice.

### Linked Issues
None

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
None
