### PR TITLE
feat: show agent  on--whoami flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ ni -v
 
 # -h, --help      | Show help
 ni -h
+
+# --whoami      | show agent
+ni --whoami
 ```
 
 <br>

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -66,6 +66,11 @@ export async function getCliCommand(
       return
   }
 
+  if (args[0] === '--whoami') {
+    console.log(`agent  ${c.cyan(agent)}`)
+    return
+  }
+
   return await fn(agent as Agent, args, {
     programmatic: options.programmatic,
     hasLock: Boolean(agent),


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

New feature: find out which package manager is currently in use

```bash
ni --whoami  # agent pnpm
```

There is no other way except to go to the root of the project to see the `.lock` file