### PR TITLE
fix: filter builtin npm scripts

### DIFF
--- a/src/commands/nr.ts
+++ b/src/commands/nr.ts
@@ -8,6 +8,8 @@ import { parseNr } from '../parse'
 import { getPackageJSON } from '../fs'
 import { runCli } from '../runner'
 
+export const builtinNpmScripts = ['preinstall', 'postinstall', 'prepublish', 'prepare', 'prepack', 'postpack', 'prepublishOnly']
+
 runCli(async (agent, args, ctx) => {
   const storage = await load()
 
@@ -35,7 +37,7 @@ runCli(async (agent, args, ctx) => {
       return
 
     const raw = names
-      .filter(i => !i[0].startsWith('?'))
+      .filter(([script]) => !script.startsWith('?') && !builtinNpmScripts.includes(script))
       .map(([key, cmd]) => ({
         key,
         cmd,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Excludes builtin npm scripts like `postinstall`, `prepack`, etc. from the selection fields in `nr`

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
