### PR TITLE
docs: allow copy for install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 <br>
 
-<pre>
-npm i -g <b>@antfu/ni</b>
-</pre>
+```
+npm i -g @antfu/ni
+```
 
 <a href='https://docs.npmjs.com/cli/v6/commands/npm'>npm</a> · <a href='https://yarnpkg.com'>yarn</a> · <a href='https://pnpm.io/'>pnpm</a> · <a href='https://bun.sh/'>bun</a>
 


### PR DESCRIPTION
surround with code block, so can copy command with one click.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Make install command block more convenient by surrounding it with code block. Now can copy command with one click.

### Linked Issues


### Additional context

screenshot (or go to https://github.com/hms5232/ni/tree/hms5232-patch-1 preview):

![圖片](https://github.com/antfu/ni/assets/43672033/7bbbc5b7-2389-4d2f-8ea5-74d003b1e5e7)


<!-- e.g. is there anything you'd like reviewers to focus on? -->
